### PR TITLE
[ROCm] Add AMD ROCm/HIP support and a standalone CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,70 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
+# Author: Jeff Daily <jeff.daily@amd.com>
+#
+# Standalone build for the testLBVH() sample. The default configuration targets
+# NVIDIA via CUDA (the .cu source is compiled by the CUDA toolchain, matching
+# the Visual Studio solution). Configuring with -DUSE_HIP=ON instead targets
+# AMD via ROCm/HIP: the sources are compiled by hipcc with the in-repo
+# cuda_to_hip.h force-included. The CUDA path is unchanged by the HIP option.
+
+cmake_minimum_required(VERSION 3.21)
+
+option(USE_HIP "Build with ROCm/HIP" OFF)
+
+if(USE_HIP)
+    project(KittenLBVH C CXX HIP)
+else()
+    project(KittenLBVH C CXX CUDA)
+endif()
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+if(USE_HIP)
+    find_package(hip REQUIRED)
+endif()
+
+include(FetchContent)
+
+# GLM 1.0.1: the system GLM 0.9.9.8 lacks __HIP__ detection; 1.0 has it
+FetchContent_Declare(
+    glm
+    GIT_REPOSITORY https://github.com/g-truc/glm.git
+    GIT_TAG        1.0.1
+    GIT_SHALLOW    TRUE
+)
+FetchContent_MakeAvailable(glm)
+
+find_package(OpenMP)
+
+set(SOURCES main.cpp lbvh.cu)
+
+if(USE_HIP)
+    set_source_files_properties(${SOURCES} PROPERTIES LANGUAGE HIP)
+    add_executable(lbvh_test ${SOURCES})
+    set_target_properties(lbvh_test PROPERTIES
+        HIP_ARCHITECTURES "${CMAKE_HIP_ARCHITECTURES}"
+    )
+    target_compile_definitions(lbvh_test PRIVATE USE_HIP)
+    target_include_directories(lbvh_test PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${CMAKE_CURRENT_SOURCE_DIR}/KittenEngine/includes
+    )
+    target_compile_options(lbvh_test PRIVATE
+        -include ${CMAKE_CURRENT_SOURCE_DIR}/cuda_to_hip.h
+    )
+    target_link_libraries(lbvh_test PRIVATE glm::glm hip::host)
+    if(OpenMP_CXX_FOUND)
+        target_link_libraries(lbvh_test PRIVATE OpenMP::OpenMP_CXX)
+    endif()
+else()
+    add_executable(lbvh_test ${SOURCES})
+    target_include_directories(lbvh_test PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${CMAKE_CURRENT_SOURCE_DIR}/KittenEngine/includes
+    )
+    target_link_libraries(lbvh_test PRIVATE glm::glm)
+    if(OpenMP_CXX_FOUND)
+        target_link_libraries(lbvh_test PRIVATE OpenMP::OpenMP_CXX)
+    endif()
+endif()

--- a/KittenEngine/includes/modules/Common.h
+++ b/KittenEngine/includes/modules/Common.h
@@ -1,9 +1,26 @@
 #pragma once
 // Jerry Hsu, 2021
 
-#define KITTEN_FUNC_DECL 
+#define KITTEN_FUNC_DECL
 
-#if __has_include("cuda_runtime.h")
+#if defined(USE_HIP)
+// ROCm/HIP build: cuda_to_hip.h is force-included ahead of this header, so it
+// has already pulled <hip/hip_runtime.h> and aliased the cuda* surface to hip*.
+#include <stdio.h>
+#include <stdlib.h>
+
+#undef KITTEN_FUNC_DECL
+#define KITTEN_FUNC_DECL __device__ __host__
+
+#define checkCudaErrors(ans) { gpuAssert((ans), __FILE__, __LINE__); }
+inline void gpuAssert(cudaError_t code, const char* file, int line, bool abort = true) {
+	if (code != cudaSuccess) {
+		fprintf(stderr, "GPUassert: %s %s %d\n", cudaGetErrorString(code), file, line);
+		if (abort) exit(code);
+	}
+}
+
+#elif __has_include("cuda_runtime.h")
 #pragma nv_diag_suppress esa_on_defaulted_function_ignored
 #include <cuda_runtime.h>
 #include <stdio.h>

--- a/README.md
+++ b/README.md
@@ -12,6 +12,16 @@ and the following blog posts
 depending on [thrust](https://thrust.github.io/) and [glm](https://github.com/g-truc/glm).
 (DO NOT INSTALL GLM DIRECTLY FROM THE CURRENT WORKING BRANCH. Only install versions taged as stable releases or through vcpkg. When in doubt, use glm version 1.0.1#3.)
 
+## AMD GPU support
+The sources also compile for AMD GPUs through ROCm/HIP. The CUDA-specific runtime includes are guarded behind `USE_HIP`, so the same `lbvh.cu`/`lbvh.cuh` build either way. The repo ships a small CUDA-to-HIP shim (`cuda_to_hip.h`) that maps the `cudaXxx` runtime onto `hipXxx`, and a `CMakeLists.txt` that builds the `testLBVH()` sample standalone:
+
+```
+cmake -B build -DUSE_HIP=ON -DCMAKE_HIP_COMPILER=hipcc -DCMAKE_HIP_ARCHITECTURES=gfx1100
+cmake --build build
+```
+
+`CMAKE_HIP_ARCHITECTURES` selects the target GPU (e.g. `gfx90a`, `gfx1100`, `gfx1201`). The shim is force-included on each HIP translation unit by the CMake build. The default NVIDIA/CUDA path is unchanged: configuring without `USE_HIP` (the default) builds with the CUDA toolchain, just as the Visual Studio solution does.
+
 ## Implementation
 This is partly rewritten/referenced from https://github.com/ToruNiina/lbvh to be much more optimized, simpler to use, and, importantly, bug free. It was written as a module of KittenEngine, a simulation framework I wrote for research. 
 

--- a/cuda_to_hip.h
+++ b/cuda_to_hip.h
@@ -1,0 +1,52 @@
+#pragma once
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// \author Jeff Daily <jeff.daily@amd.com>
+//
+// CUDA-to-HIP compatibility shim for the ROCm build. Force-included (compiler
+// -include flag) on every HIP translation unit so it is parsed before any
+// project or GLM header, then again pulled in by sources that name CUDA symbols.
+//
+// Aliases the cuda* runtime/stream surface the sources use to hip*. The HIP
+// runtime is included first so its __device__ memcpy/memset overloads are in
+// scope for any header the sources pull in afterwards.
+//
+// GLM device-qualifier note: the kernels call glm:: math from __device__ code.
+// GLM only decorates those __host__ __device__ when it detects a device compiler.
+// GLM >= 1.0 recognizes hipcc via __HIP__ directly (glm/simd/platform.h ->
+// GLM_COMPILER_HIP), so the ROCm build pins GLM 1.0.x (FetchContent in
+// CMakeLists.txt) and needs no compiler-identity spoofing here.
+
+#if defined(USE_HIP)
+
+#include <cstring>
+#include <cstdlib>
+#include <cstdio>
+
+#include <hip/hip_runtime.h>
+
+// --- runtime API -----------------------------------------------------------
+#define cudaError_t                         hipError_t
+#define cudaSuccess                         hipSuccess
+#define cudaGetErrorString                  hipGetErrorString
+#define cudaGetLastError                    hipGetLastError
+#define cudaPeekAtLastError                 hipPeekAtLastError
+#define cudaDeviceSynchronize               hipDeviceSynchronize
+
+#define cudaMalloc                          hipMalloc
+#define cudaFree                            hipFree
+#define cudaMemcpy                          hipMemcpy
+#define cudaMemcpyAsync                     hipMemcpyAsync
+#define cudaMemset                          hipMemset
+#define cudaMemsetAsync                     hipMemsetAsync
+#define cudaMemcpyHostToDevice              hipMemcpyHostToDevice
+#define cudaMemcpyDeviceToHost              hipMemcpyDeviceToHost
+#define cudaMemcpyDeviceToDevice            hipMemcpyDeviceToDevice
+#define cudaMemcpyKind                      hipMemcpyKind
+
+// --- streams ---------------------------------------------------------------
+#define cudaStream_t                        hipStream_t
+#define cudaStreamCreate                    hipStreamCreate
+#define cudaStreamDestroy                   hipStreamDestroy
+#define cudaStreamSynchronize               hipStreamSynchronize
+
+#endif // USE_HIP

--- a/lbvh.cu
+++ b/lbvh.cu
@@ -1,7 +1,9 @@
 #include "lbvh.cuh"
 
+#if !defined(USE_HIP)
 #include <cuda_runtime.h>
 #include <device_launch_parameters.h>
+#endif
 
 #include <thrust/host_vector.h>
 #include <thrust/device_vector.h>
@@ -302,7 +304,7 @@ namespace Kitten {
 			const uint32_t* queryIDs, const Bound<3, float>* queryAABBs, const int numQueries, int stackSize) {
 
 			// This is a bit ugly but we want to compile the kernel for all stack sizes.
-#define DISPATCH_QUERY(N) case N: lbvhQueryKernel<IGNORE_SELF, N> << <(numQueries + 127) / 128, 128 >> > (res, resCounter, maxRes, nodes, objIDs, queryIDs, queryAABBs, numQueries); break;
+#define DISPATCH_QUERY(N) case N: lbvhQueryKernel<IGNORE_SELF, N> <<<(numQueries + 127) / 128, 128 >>> (res, resCounter, maxRes, nodes, objIDs, queryIDs, queryAABBs, numQueries); break;
 			switch (stackSize) {
 			default:
 				DISPATCH_QUERY(32); DISPATCH_QUERY(31); DISPATCH_QUERY(30); DISPATCH_QUERY(29); DISPATCH_QUERY(28); DISPATCH_QUERY(27); DISPATCH_QUERY(26); DISPATCH_QUERY(25);
@@ -327,7 +329,7 @@ namespace Kitten {
 		cudaMemset(thrust::raw_pointer_cast(impl->d_flags.data()), 0, sizeof(uint32_t) * (numObjs - 1));
 
 		// Go through and merge all the aabbs up from the leaf nodes
-		LBVHKernels::mergeUpKernel << <(numObjs + 255) / 256, 256 >> > (
+		LBVHKernels::mergeUpKernel <<<(numObjs + 255) / 256, 256 >>> (
 			thrust::raw_pointer_cast(impl->d_nodes.data()),
 			thrust::raw_pointer_cast(impl->d_leafParents.data()),
 			thrust::raw_pointer_cast(impl->d_objs),
@@ -361,7 +363,7 @@ namespace Kitten {
 		});
 
 		// Compute morton codes. These don't have to be unique here.
-		LBVHKernels::mortonKernel<float> << <(numObjs + 255) / 256, 256 >> > (
+		LBVHKernels::mortonKernel<float> <<<(numObjs + 255) / 256, 256 >>> (
 			devicePtr, thrust::raw_pointer_cast(impl->d_morton.data()),
 			thrust::raw_pointer_cast(impl->d_objIDs.data()), rootBounds, numObjs);
 
@@ -369,7 +371,7 @@ namespace Kitten {
 		thrust::stable_sort_by_key(impl->d_morton.begin(), impl->d_morton.end(), impl->d_objIDs.begin());
 
 		// Build out the internal nodes
-		LBVHKernels::lbvhBuildInternalKernel << <(numInternalNodes + 255) / 256, 256 >> > (
+		LBVHKernels::lbvhBuildInternalKernel <<<(numInternalNodes + 255) / 256, 256 >>> (
 			thrust::raw_pointer_cast(impl->d_nodes.data()),
 			thrust::raw_pointer_cast(impl->d_leafParents.data()),
 			thrust::raw_pointer_cast(impl->d_morton.data()),

--- a/lbvh.cuh
+++ b/lbvh.cuh
@@ -1,8 +1,10 @@
 #pragma once
 // Jerry Hsu, 2024
 
+#if !defined(USE_HIP)
 #include <cuda_runtime.h>
 #include <device_launch_parameters.h>
+#endif
 
 #include <memory>
 #include <KittenEngine/includes/modules/Common.h>

--- a/main.cpp
+++ b/main.cpp
@@ -2,6 +2,7 @@
 #include <iostream>
 #include "lbvh.cuh"
 
-void main(int arg, char** args) {
+int main(int arg, char** args) {
 	Kitten::testLBVH();
+	return 0;
 }


### PR DESCRIPTION
## Summary

KittenGpuLBVH was NVIDIA/CUDA only (the `.cu` sources unconditionally include `<cuda_runtime.h>` / `<device_launch_parameters.h>`, and the only build is the Visual Studio solution). This adds an opt-in AMD ROCm/HIP path that compiles the same `lbvh.cu`/`lbvh.cuh` with hipcc, plus a small standalone CMake build for the `testLBVH()` sample so the BVH can be built and checked without the full KittenEngine solution. The default (`USE_HIP` OFF) CUDA path is unchanged.

(This is also what lets the YarnBall simulator, which vendors this repo as a submodule, build for AMD GPUs.)

## What changed

- **`lbvh.cu` / `lbvh.cuh`**: the CUDA-only runtime includes are guarded behind `#if !defined(USE_HIP)`; the compat shim supplies the runtime on HIP. The spaced `<< <` / `>> >` kernel-launch tokens are normalized to `<<<` / `>>>`.
- **`cuda_to_hip.h`** (new): a small shim that includes `<hip/hip_runtime.h>` and maps the `cudaXxx` runtime/error surface used here onto `hipXxx`. Force-included on each HIP translation unit by the CMake build, so the sources need no per-include edits.
- **`KittenEngine/includes/modules/Common.h`**: a `USE_HIP` branch parallel to the existing `__has_include("cuda_runtime.h")` branch that decorates `KITTEN_FUNC_DECL` with `__device__ __host__` and provides the `gpuAssert` helper.
- **`CMakeLists.txt`** (new): builds the `testLBVH()` sample (`main.cpp` + `lbvh.cu`) as `lbvh_test`. `project(... CUDA)` by default, or `project(... HIP)` with `-DUSE_HIP=ON` (force-includes the shim, sets `HIP_ARCHITECTURES`). GLM 1.0.1 is fetched because the system GLM 0.9.9.8 lacks the `__HIP__` device-decoration path.
- **`README.md`**: an "AMD GPU support" section documenting the `USE_HIP` build.

## Test plan

Built the standalone sample and ran its built-in self-check (build a 100K-object LBVH on the GPU, query all collision pairs, compare against a brute-force CPU pass) on real AMD GPUs:

```bash
cmake -B build -DUSE_HIP=ON -DCMAKE_HIP_COMPILER=hipcc \
  -DCMAKE_HIP_ARCHITECTURES=gfx90a -DCMAKE_BUILD_TYPE=Release
cmake --build build -j
./build/lbvh_test
```

- **gfx90a** (Instinct MI250X, ROCm 7.2.1): 338 GPU pairs == 338 CPU pairs, self-check complete.
- **gfx1100** (Radeon PRO W7800, ROCm 7.2.1): 338 == 338, self-check complete.
- **gfx1201** (Radeon RX 9070 XT, Windows, ROCm 7.x): 356 == 356, self-check complete.

Each binary embeds the corresponding `hipv4-amdgcn-amd-amdhsa--gfx*` code objects. The default CUDA build path is unchanged.

This work was authored with assistance from Claude (Anthropic).
